### PR TITLE
Refactor crawler initialization and prompt loading

### DIFF
--- a/src/crawler/crawler.py
+++ b/src/crawler/crawler.py
@@ -6,7 +6,12 @@ from .readability_extractor import ReadabilityExtractor
 
 
 class Crawler:
+    def __init__(self) -> None:
+        self.jina_client = JinaClient()
+        self.extractor = ReadabilityExtractor()
+
     def crawl(self, url: str) -> Article:
+        """Fetch a URL and return the parsed article."""
         # To help LLMs better understand content, we extract clean
         # articles from HTML, convert them to markdown, and split
         # them into text and image blocks for one single and unified
@@ -17,10 +22,8 @@ class Crawler:
         #
         # Instead of using Jina's own markdown converter, we'll use
         # our own solution to get better readability results.
-        jina_client = JinaClient()
-        html = jina_client.crawl(url, return_format="html")
-        extractor = ReadabilityExtractor()
-        article = extractor.extract_article(html)
+        html = self.jina_client.crawl(url, return_format="html")
+        article = self.extractor.extract_article(html)
         article.url = url
         return article
 

--- a/src/prompts/template.py
+++ b/src/prompts/template.py
@@ -7,7 +7,9 @@ from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
 def get_prompt_template(prompt_name: str) -> str:
-    template = open(os.path.join(os.path.dirname(__file__), f"{prompt_name}.md")).read()
+    file_path = os.path.join(os.path.dirname(__file__), f"{prompt_name}.md")
+    with open(file_path, encoding="utf-8") as f:
+        template = f.read()
     # Escape curly braces using backslash
     template = template.replace("{", "{{").replace("}", "}}")
     # Replace `<<VAR>>` with `{VAR}`


### PR DESCRIPTION
## Summary
- improve prompt template loading by using context manager
- reuse crawler dependencies by creating them in `__init__`

## Testing
- `make lint`
- `make format`
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_684686c5ea6483318bac00fb2e924c1e