### PR TITLE
Add insight analyst agent

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,3 +1,3 @@
-from .agents import research_agent, coder_agent, browser_agent
+from .agents import research_agent, coder_agent, browser_agent, insight_agent
 
-__all__ = ["research_agent", "coder_agent", "browser_agent"]
+__all__ = ["research_agent", "coder_agent", "browser_agent", "insight_agent"]

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -30,3 +30,9 @@ browser_agent = create_react_agent(
     tools=[browser_tool],
     prompt=lambda state: apply_prompt_template("browser", state),
 )
+
+insight_agent = create_react_agent(
+    get_llm_by_type(AGENT_LLM_MAP["insight_analyst"]),
+    tools=[tavily_tool, crawl_tool, python_repl_tool],
+    prompt=lambda state: apply_prompt_template("insight_analyst", state),
+)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -17,7 +17,7 @@ from .env import (
 from .tools import TAVILY_MAX_RESULTS
 
 # Team configuration
-TEAM_MEMBERS = ["researcher", "coder", "browser", "reporter"]
+TEAM_MEMBERS = ["researcher", "coder", "browser", "reporter", "insight_analyst"]
 
 __all__ = [
     # Reasoning LLM

--- a/src/config/agents.py
+++ b/src/config/agents.py
@@ -12,4 +12,5 @@ AGENT_LLM_MAP: dict[str, LLMType] = {
     "coder": "basic",  # 编程任务使用basic llm
     "browser": "vision",  # 浏览器操作使用vision llm
     "reporter": "basic",  # 编写报告使用basic llm
+    "insight_analyst": "reasoning",  # 数据分析使用reasoning llm
 }

--- a/src/graph/builder.py
+++ b/src/graph/builder.py
@@ -7,6 +7,7 @@ from .nodes import (
     code_node,
     coordinator_node,
     browser_node,
+    insight_node,
     reporter_node,
     planner_node,
 )
@@ -22,5 +23,6 @@ def build_graph():
     builder.add_node("researcher", research_node)
     builder.add_node("coder", code_node)
     builder.add_node("browser", browser_node)
+    builder.add_node("insight_analyst", insight_node)
     builder.add_node("reporter", reporter_node)
     return builder.compile()

--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -6,7 +6,7 @@ from langchain_core.messages import HumanMessage
 from langgraph.types import Command
 from langgraph.graph import END
 
-from src.agents import research_agent, coder_agent, browser_agent
+from src.agents import research_agent, coder_agent, browser_agent, insight_agent
 from src.agents.llm import get_llm_by_type
 from src.config import TEAM_MEMBERS
 from src.config.agents import AGENT_LLM_MAP
@@ -75,6 +75,27 @@ def browser_node(state: State) -> Command[Literal["supervisor"]]:
                         "browser", result["messages"][-1].content
                     ),
                     name="browser",
+                )
+            ]
+        },
+        goto="supervisor",
+    )
+
+
+def insight_node(state: State) -> Command[Literal["supervisor"]]:
+    """Node for the insight analyst agent."""
+    logger.info("Insight analyst agent starting task")
+    result = insight_agent.invoke(state)
+    logger.info("Insight analyst agent completed task")
+    logger.debug(f"Insight analyst response: {result['messages'][-1].content}")
+    return Command(
+        update={
+            "messages": [
+                HumanMessage(
+                    content=RESPONSE_FORMAT.format(
+                        "insight_analyst", result["messages"][-1].content
+                    ),
+                    name="insight_analyst",
                 )
             ]
         },

--- a/src/prompts/insight_analyst.md
+++ b/src/prompts/insight_analyst.md
@@ -1,0 +1,22 @@
+---
+CURRENT_TIME: <<CURRENT_TIME>>
+---
+
+You are an insight analyst that gathers information, analyzes data and summarizes consumer needs.
+
+# Steps
+1. Use **tavily_tool** to search for market or consumer trends related to the topic.
+2. Use **crawl_tool** to fetch detailed information from relevant URLs.
+3. When necessary use **python_repl_tool** to analyze or transform the data.
+4. Synthesize the findings into clear consumer needs.
+
+# Output Format
+Provide a concise Markdown report including:
+- **Research Overview** summarizing search and crawl results.
+- **Data Analysis** explaining any calculations or reasoning.
+- **Consumer Needs** as actionable insights.
+
+# Notes
+- Verify credibility of all sources.
+- Do not fabricate data or assumptions.
+- Always reply in the same language as the initial question.

--- a/src/prompts/supervisor.md
+++ b/src/prompts/supervisor.md
@@ -18,3 +18,4 @@ Always respond with a valid JSON object containing only the 'next' key and a sin
 - **`coder`**: Executes Python or Bash commands, performs mathematical calculations, and outputs a Markdown report. Must be used for all mathematical computations.
 - **`browser`**: Directly interacts with web pages, performing complex operations and interactions. You can also leverage `browser` to perform in-domain search, like Facebook, Instgram, Github, etc.
 - **`reporter`**: Wriite a professional report based on the result of each step.
+- **`insight_analyst`**: Gathers data using search and crawling tools, performs analysis with Python, and summarizes consumer needs.

--- a/tests/integration/test_insight_agent.py
+++ b/tests/integration/test_insight_agent.py
@@ -1,0 +1,9 @@
+from src.config import TEAM_MEMBERS
+from src.graph import build_graph
+
+
+def test_insight_agent_registered():
+    """Ensure the insight analyst is registered in the workflow graph."""
+    assert "insight_analyst" in TEAM_MEMBERS
+    graph = build_graph()
+    assert "insight_analyst" in graph.get_graph().nodes


### PR DESCRIPTION
## Summary
- add prompt for new `insight_analyst` agent
- register the agent in configuration
- create insight agent instance
- add workflow node and integrate it into the graph
- update supervisor prompt to describe the new agent
- include test verifying node registration

## Testing
- `make format`
- `make lint`
- `pytest -q --override-ini addopts=''` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_684689cf6ce483318caec8963c1abde1