### PR TITLE
Add multi-provider backend and update chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ agent_history.gif
 .env
 
 .idea/
+
+# Node
+node_modules/
+express-server/.env
+

--- a/ai-role-platform/.env.example
+++ b/ai-role-platform/.env.example
@@ -1,0 +1,4 @@
+# Base URL of the backend Express server
+VITE_API_BASE=http://localhost:3001
+# Default provider to use when sending chat requests
+VITE_PROVIDER=openai

--- a/ai-role-platform/README.md
+++ b/ai-role-platform/README.md
@@ -1,0 +1,35 @@
+# AI Role Platform
+
+This is a React + Tailwind project created with Vite. It demonstrates a simple
+AI role system. The homepage shows a list of roles. Clicking an avatar navigates
+to a chat page that displays the role's system prompt.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:3000` by default.
+
+### Configuration
+
+Copy `.env.example` to `.env` to configure the backend URL and default provider:
+
+```bash
+cp .env.example .env
+# edit .env and set VITE_API_BASE and VITE_PROVIDER
+```
+
+### Chat History
+
+Conversations are stored in your browser's `localStorage`. Each request sends the
+accumulated history to the backend using the configured provider while trimming
+the oldest messages so the total token count stays under roughly 4k tokens.
+
+### UI Features
+
+The chat interface is styled with Tailwind CSS. Messages scroll smoothly and fade in as they arrive. Input fields animate on focus and role cards lift slightly when hovered to provide an interactive feel.

--- a/ai-role-platform/index.html
+++ b/ai-role-platform/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Role Platform</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/ai-role-platform/package.json
+++ b/ai-role-platform/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ai-role-platform",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.14",
+    "tailwindcss": "^3.3.5",
+    "vite": "^4.0.0"
+  }
+}

--- a/ai-role-platform/postcss.config.js
+++ b/ai-role-platform/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ai-role-platform/src/App.jsx
+++ b/ai-role-platform/src/App.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import RoleList from './components/RoleList';
+import ChatPage from './components/ChatPage';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<RoleList />} />
+        <Route path="/chat/:id" element={<ChatPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/ai-role-platform/src/components/ChatPage.jsx
+++ b/ai-role-platform/src/components/ChatPage.jsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { roles } from '../data/roles';
+
+function ChatPage() {
+  const { id } = useParams();
+  const role = roles.find(r => String(r.id) === id);
+  const storageKey = `chat_${id}`;
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef(null);
+  const provider = import.meta.env.VITE_PROVIDER || 'openai';
+  const apiBase = import.meta.env.VITE_API_BASE || 'http://localhost:3001';
+
+  useEffect(() => {
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      try {
+        setMessages(JSON.parse(saved));
+      } catch {
+        // ignore malformed data
+      }
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    localStorage.setItem(storageKey, JSON.stringify(messages));
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, storageKey]);
+
+  const MAX_CHARS = 12000; // rough limit for 4k tokens
+
+  const limitHistory = hist => {
+    let total = role.systemPrompt.length + hist.reduce((a, m) => a + m.content.length, 0);
+    const copy = [...hist];
+    while (total > MAX_CHARS && copy.length) {
+      const removed = copy.shift();
+      total -= removed.content.length;
+    }
+    return copy;
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    const userMsg = { role: 'user', content: input.trim() };
+    const history = limitHistory([...messages, userMsg]);
+    setMessages(history);
+    setInput('');
+
+    try {
+      const res = await fetch(`${apiBase}/chat`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          provider,
+          model: 'gpt-3.5-turbo',
+          messages: [
+            { role: 'system', content: role.systemPrompt },
+            ...history,
+          ],
+        }),
+      });
+      const data = await res.json();
+      const reply = data.choices?.[0]?.message?.content?.trim();
+      if (reply) {
+        setMessages(prev => [...prev, { role: 'assistant', content: reply }]);
+      }
+    } catch (err) {
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: `Error: ${err.message}` },
+      ]);
+    }
+  };
+
+  if (!role) {
+    return (
+      <div className="p-4 text-center">
+        <p className="mb-4">Role not found.</p>
+        <Link to="/" className="text-blue-500 underline">Back</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <Link to="/" className="text-blue-500 underline">← Back to roles</Link>
+      <div className="text-center mt-4">
+        <img
+          src={role.avatar}
+          alt={role.name}
+          className="mx-auto mb-2 rounded-full w-24 h-24 object-cover"
+        />
+        <h1 className="text-2xl font-bold mb-2">{role.name}</h1>
+        <p className="italic text-gray-600 mb-4">System Prompt: {role.systemPrompt}</p>
+        <div className="p-4 border rounded bg-white h-96 overflow-y-auto mb-4 text-left flex flex-col space-y-2">
+          {messages.map((msg, idx) => (
+            <div key={idx} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`px-3 py-2 rounded-lg max-w-[70%] break-words transition-opacity duration-300 animate-fade-in ${
+                  msg.role === 'user' ? 'bg-blue-500 text-white' : 'bg-gray-200'
+                }`}
+              >
+                {msg.content}
+              </div>
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+        <form onSubmit={handleSubmit} className="flex gap-2 mt-2">
+          <input
+            type="text"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            className="flex-1 border rounded p-2 focus:outline-none focus:ring focus:ring-blue-200 transition-all"
+            placeholder="Type your message..."
+          />
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 transition-colors">
+            Send
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ChatPage;

--- a/ai-role-platform/src/components/RoleCard.jsx
+++ b/ai-role-platform/src/components/RoleCard.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function RoleCard({ role }) {
+  return (
+    <Link
+      to={`/chat/${role.id}`}
+      className="bg-white rounded shadow p-4 hover:shadow-xl hover:-translate-y-1 transform transition-all block text-center"
+    >
+      <img
+        src={role.avatar}
+        alt={role.name}
+        className="mx-auto mb-2 rounded-full w-24 h-24 object-cover"
+      />
+      <h2 className="text-xl font-semibold mb-1">{role.name}</h2>
+    </Link>
+  );
+}
+
+export default RoleCard;

--- a/ai-role-platform/src/components/RoleList.jsx
+++ b/ai-role-platform/src/components/RoleList.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import RoleCard from './RoleCard';
+import { roles } from '../data/roles';
+
+function RoleList() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4 text-center">Choose Your Role</h1>
+      <div className="grid gap-4 md:grid-cols-3 sm:grid-cols-2">
+        {roles.map(role => (
+          <RoleCard key={role.id} role={role} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default RoleList;

--- a/ai-role-platform/src/data/roles.js
+++ b/ai-role-platform/src/data/roles.js
@@ -1,0 +1,20 @@
+export const roles = [
+  {
+    id: 1,
+    name: 'Strategist',
+    avatar: 'https://placehold.co/100x100?text=S',
+    systemPrompt: 'Thinks several steps ahead when solving problems.'
+  },
+  {
+    id: 2,
+    name: 'Philosopher',
+    avatar: 'https://placehold.co/100x100?text=P',
+    systemPrompt: 'Analyzes questions from a metaphysical angle.'
+  },
+  {
+    id: 3,
+    name: 'Comedian',
+    avatar: 'https://placehold.co/100x100?text=C',
+    systemPrompt: 'Always provides a humorous perspective.'
+  }
+];

--- a/ai-role-platform/src/index.css
+++ b/ai-role-platform/src/index.css
@@ -1,0 +1,20 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@layer utilities {
+  .animate-fade-in {
+    animation: fade-in 0.2s ease-in-out;
+  }
+}

--- a/ai-role-platform/src/main.jsx
+++ b/ai-role-platform/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ai-role-platform/tailwind.config.js
+++ b/ai-role-platform/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/ai-role-platform/vite.config.js
+++ b/ai-role-platform/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});

--- a/express-server/.env.example
+++ b/express-server/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and set any API keys you plan to use
+OPENAI_API_KEY=sk-your-openai-key
+ANTHROPIC_API_KEY=sk-your-anthropic-key
+GEMINI_API_KEY=your-gemini-key
+PORT=3001

--- a/express-server/README.md
+++ b/express-server/README.md
@@ -1,0 +1,25 @@
+# Express Server
+
+This simple Node.js backend forwards chat requests to various LLM providers.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example environment file and add any API keys you want to use:
+   ```bash
+   cp .env.example .env
+   # edit .env to set OPENAI_API_KEY, ANTHROPIC_API_KEY or GEMINI_API_KEY
+   ```
+
+## Running
+
+Start the server with:
+```bash
+npm start
+```
+The server listens on the port defined in `.env` (default `3001`).
+
+Send a POST request to `/chat` with a JSON body containing `messages` and optional `model`, `provider`, or `max_tokens` fields. `provider` can be `openai`, `claude`, or `gemini`.

--- a/express-server/index.js
+++ b/express-server/index.js
@@ -1,0 +1,69 @@
+import dotenv from 'dotenv';
+import express from 'express';
+import axios from 'axios';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+app.post('/chat', async (req, res) => {
+  const {
+    messages,
+    model = 'gpt-3.5-turbo',
+    max_tokens,
+    provider = 'openai',
+  } = req.body;
+  if (!Array.isArray(messages)) {
+    return res.status(400).json({ error: 'messages must be an array' });
+  }
+
+  try {
+    let response;
+    if (provider === 'claude') {
+      response = await axios.post(
+        'https://api.anthropic.com/v1/messages',
+        { model: model || 'claude-3-opus-20240229', messages, max_tokens },
+        {
+          headers: {
+            'content-type': 'application/json',
+            'x-api-key': process.env.ANTHROPIC_API_KEY,
+            'anthropic-version': '2023-06-01',
+          },
+        }
+      );
+    } else if (provider === 'gemini') {
+      const url =
+        `https://generativelanguage.googleapis.com/v1beta/models/${
+          model || 'gemini-pro'
+        }:generateContent?key=${process.env.GEMINI_API_KEY}`;
+      const contents = messages.map(m => ({ role: m.role, parts: [{ text: m.content }] }));
+      response = await axios.post(
+        url,
+        { contents },
+        { headers: { 'content-type': 'application/json' } }
+      );
+    } else {
+      response = await axios.post(
+        'https://api.openai.com/v1/chat/completions',
+        { model, messages, max_tokens },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          },
+        }
+      );
+    }
+    res.json(response.data);
+  } catch (err) {
+    const msg = err.response?.data || err.message;
+    console.error('LLM API error:', msg);
+    res.status(500).json({ error: 'LLM request failed' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Express server listening on port ${PORT}`);
+});

--- a/express-server/package.json
+++ b/express-server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "express-server",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- extend Express server to support `claude` and `gemini` providers
- update `.env.example` files and docs with new API key options
- use backend endpoint from the React chat page
- document environment variables for the React frontend

## Testing
- `make format`
- `make lint`
- `pytest` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68469ad515748331829a5c0a87d64898